### PR TITLE
Make use of numba for further speed up.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.1.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -9,30 +9,30 @@ with open("README.md") as readme_file:
     readme = readme_file.read()
 
 test_requirements = ["scipy"
-    
+
 ]
 
 docs_requirements = [
-    
+
 ]
 
 setup_requirements = [
-    
+
 ]
 
 dev_requirements = [
     *test_requirements,
     *docs_requirements,
     *setup_requirements,
-    
+
     "bump2version>=1.0.0",
     "ipython>=7.5.0",
-    
+
     "twine>=1.13.0",
     "wheel>=0.33.1",
 ]
 
-requirements = ["numpy", "pytest"]
+requirements = ["numpy", "pytest", "numba"]
 
 extra_requirements = {
     "test": test_requirements,

--- a/src/test/nnls_comparison.py
+++ b/src/test/nnls_comparison.py
@@ -11,8 +11,6 @@ from time import time
 
 from fnnls.fnnls import fnnls
 
-
-
 class nnls_comparison():
 
     def __init__(self):
@@ -28,10 +26,10 @@ class nnls_comparison():
         ----------
         repetitions: int
             The number of times to run at optimizer at each dimensions
-            for precision. 
+            for precision.
 
         dimensions: numpy array
-            A list of dimensions of matrix A and vector x to use 
+            A list of dimensions of matrix A and vector x to use
             for testing.
 
         optimizers: list
@@ -69,11 +67,11 @@ class nnls_comparison():
 
                     #Measure the speed of running the optimizer
                     start = time()
-                    
+
                     [d, res] = optimizer(Z, x)
 
                     end = time()
-                
+
                     time_total += end - start
                     res_total += res
                     ds.append(d)
@@ -151,7 +149,7 @@ class nnls_comparison():
             for j in range(len(residuals_1)):
                 avg_diff += np.linalg.norm(residuals_1[j] - residuals_2[j]) / np.linalg.norm(residuals_1[j])
             differences.append(avg_diff / len(residuals_1))
-            
+
         return differences
 
 
@@ -166,7 +164,8 @@ if SPARSE:
 else:
     generator = np.random.randn
 
-
+# Run fnnls once for JIT
+fnnls(np.random.rand(10,10), np.random.rand(10))
 
 #Declare parameters for testing
 repetitions = 25


### PR DESCRIPTION
we went from:

![image](https://user-images.githubusercontent.com/50950962/147250580-a18304bc-4288-4e0a-a52d-a716db3acfda.png)

to 

![image](https://user-images.githubusercontent.com/50950962/147250543-03ec7278-ed04-4fb6-b9fe-9914ecf886b3.png)

At least on my installation...

However, to make this feasible I had to remove the support for different solvers.
Also the support for different solvers was dropped.
